### PR TITLE
Add Git services

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-devops-extension-api",
-  "version": "1.146.1",
+  "version": "1.146.2",
   "description": "REST client libraries and contracts for Azure DevOps web extension developers.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-devops-extension-api",
-  "version": "1.146.0",
+  "version": "1.146.1",
   "description": "REST client libraries and contracts for Azure DevOps web extension developers.",
   "repository": {
     "type": "git",

--- a/src/Git/GitServices.ts
+++ b/src/Git/GitServices.ts
@@ -1,0 +1,18 @@
+import { GitRepository } from "../Git/Git";
+
+/**
+ * Contribution ids of Azure Pipelines services which can be obtained from DevOps.getService
+ */
+export enum GitServiceIds {
+    VersionControlRepositoryService = "ms.vss-code-web.vc-repository-service"
+}
+
+/**
+ * Host service for accessing repository information.
+ */
+export interface IVersionControlRepositoryService {
+    /**
+     * Gets the currently selected Git repository. Returns null if a Git repository is not currently selected.
+     */
+    getCurrentGitRepository(): Promise<GitRepository | null>;
+}

--- a/src/Git/index.ts
+++ b/src/Git/index.ts
@@ -1,2 +1,3 @@
 export * from "./Git";
 export * from "./GitClient";
+export * from "./GitServices";


### PR DESCRIPTION
This is a migration of a service we had made available to the old SDK. The AzureDev Ops work was done in M146.

I have a sample in the works for after this merges here.