### PR TITLE
Add filter API methods to IWorkItemFormService

### DIFF
--- a/src/WorkItemTracking/WorkItemTrackingServices.ts
+++ b/src/WorkItemTracking/WorkItemTrackingServices.ts
@@ -146,9 +146,9 @@ export interface IWorkItemFormService {
      * Gets only filtered allowed values for the field on the active work item.
      * 
      * @param {string} fieldReferenceName Field reference name.
-     * @returns {Promise<Object[]>} A promise that returns array of filtered allowed values.
+     * @returns {Promise<string[]>} A promise that returns array of filtered allowed values.
      */
-    getFilteredAllowedFieldValues(fieldReferenceName: string): Promise<Object[]>;
+    getFilteredAllowedFieldValues(fieldReferenceName: string): Promise<string[]>;
     /**
     * Gets the allowed values for the field on the active work item.
     *

--- a/src/WorkItemTracking/WorkItemTrackingServices.ts
+++ b/src/WorkItemTracking/WorkItemTrackingServices.ts
@@ -136,6 +136,20 @@ export interface IWorkItemFormService {
     */
     setFieldValues(fields: { [fieldName: string]: Object }): Promise<{ [fieldName: string]: boolean }>;
     /**
+     * Filters the allowed values for the field on the active work item. This could only be applied to the fields with a picklist. 
+     * 
+     * @param {string} fieldReferenceName Field reference name.
+     * @param {string[]} values Filtered field values. Values should be a subset of the field's allowed values.
+     */
+    filterAllowedFieldValues(fieldReferenceName: string, values: string[]): Promise<void>;
+    /**
+     * Gets only filtered allowed values for the field on the active work item.
+     * 
+     * @param {string} fieldReferenceName Field reference name.
+     * @returns {Promise<Object[]>} A promise that returns array of filtered allowed values.
+     */
+    getFilteredAllowedFieldValues(fieldReferenceName: string): Promise<Object[]>;
+    /**
     * Gets the allowed values for the field on the active work item.
     *
     * @param {string} fieldReferenceName Field reference name


### PR DESCRIPTION
Change adds definitions for filterAllowedFieldValues and getFilteredAllowedFieldValues methods to the IWorkItemFormService.