### PR TITLE
Fixing getClassificationNodes api to support no ids

### DIFF
--- a/src/WorkItemTracking/WorkItemTrackingClient.ts
+++ b/src/WorkItemTracking/WorkItemTrackingClient.ts
@@ -211,16 +211,19 @@ export class WorkItemTrackingRestClient extends RestClientBase {
      */
     public async getClassificationNodes(
         project: string,
-        ids: number[],
+        ids: number[] | undefined,
         depth?: number,
         errorPolicy?: WorkItemTracking.ClassificationNodesErrorPolicy
         ): Promise<WorkItemTracking.WorkItemClassificationNode[]> {
 
         const queryValues: any = {
-            ids: ids && ids.join(","),
             '$depth': depth,
             errorPolicy: errorPolicy
         };
+
+        if (ids && ids.length > 0) {
+            queryValues["ids"] = ids.join(",");
+        }
 
         return this.beginRequest<WorkItemTracking.WorkItemClassificationNode[]>({
             apiVersion: "5.0",


### PR DESCRIPTION
getClassificationNodes should support not passing ids. [Docs](https://docs.microsoft.com/en-us/rest/api/azure/devops/wit/Classification%20Nodes/Get%20Classification%20Nodes?view=azure-devops-rest-5.1)

This change makes the @ids parameter optional by allowing undefined as a valid input type, it also only adds the ids property to queryParams if it is defined and has any elements. 