### PR TITLE
Adding isDisabled field to GitRepository

### DIFF
--- a/src/Git/Git.ts
+++ b/src/Git/Git.ts
@@ -2312,6 +2312,7 @@ export interface GitRepository {
     url: string;
     validRemoteUrls: string[];
     webUrl: string;
+    isDisabled: boolean;
 }
 
 export interface GitRepositoryCreateOptions {


### PR DESCRIPTION
Due the result of REST API from Azure DevOps Extension API returns the isDisabled field, it's important to have it also in the model.