### PR TITLE
Export Pipelines client

### DIFF
--- a/src/Pipelines/index.ts
+++ b/src/Pipelines/index.ts
@@ -1,0 +1,2 @@
+export * from "./Pipelines";
+export * from "./PipelinesClient";


### PR DESCRIPTION
It looks like there's a fully functional pipelines client that isn't visible because it isn't being exported.
We would like this to be able to query _pipeline_ (not build) artifacts.