### PR TITLE
Add support for Widget & Widget Configuration extension contributions

### DIFF
--- a/src/Dashboard/WidgetConfigHelpers.ts
+++ b/src/Dashboard/WidgetConfigHelpers.ts
@@ -1,0 +1,43 @@
+/**
+ * From /Tfs/WebPlatform/Client/TFS/Dashboards/WidgetConfigHelpers.ts
+ */
+
+import { EventArgs } from "./WidgetContracts";
+
+export class ConfigurationEvent {
+    /**
+    * Configuration has changed. When this event is notified, the preview is updated and Save button is enabled.
+    *
+    * The payload expected when notifying this event: { data: customSettings }
+    *
+    * {customSettings} is the serialized custom config settings pertaining to the widget.
+    */
+    public static ConfigurationChange: string = "ms.vss-dashboards-web.configurationChange";
+
+    /**
+     * Configuration tries to execute API calls and fails. When this event is notified, the config does not render a view and we pass an error message to the configuration host.
+     *
+     * The payload expected when notifying this event: { data: string }
+     *
+     * {string} is the error message that is displayed at the top of the configuration.
+     */
+    public static ConfigurationError: string = "ms.vss-dashboards-web.configurationError";
+
+    /**
+     * Widget configuration general settings changed. When this event is notified, the widget name or widget size is updated.
+     *
+     * The payload expected when notifying this event: { data: { IGeneralSettings } }
+     *
+     * {generalSettings} is the serialized object containing WidgetName and WidgetSize
+     */
+    public static GeneralSettingsChanged: string = "ms.vss-dashboards-web.generalSettingsChanged";
+
+    /**
+     * @param payload the event arguments we pass when we want to notify the configuration.
+     */
+    public static Args<T>(payload: T): EventArgs<T> {
+        return {
+            data: payload
+        };
+    }
+}

--- a/src/Dashboard/WidgetContracts.ts
+++ b/src/Dashboard/WidgetContracts.ts
@@ -1,0 +1,226 @@
+/**
+ * From /Tfs/WebPlatform/Client/TFS/Dashboards/WidgetContracts.ts
+ */
+
+import { LightboxOptions, SemanticVersion, WidgetSize } from "./Dashboard";
+
+/**
+ * settings of the widget that encapsulate their serialized data and version support.
+ */
+export interface CustomSettings {
+    /**
+     * the settings data serialized as a string.
+     */
+    data: string;
+    /**
+     * (Optional) version for the settings represented as a semantic version object.
+     * If none is available, the version defaults to {major:1, minor:0, patch:0} or "1.0.0"
+     */
+    version?: SemanticVersion;
+}
+
+/**
+ * A description of widget state, satisfying requirements for rendering a widget (Does not contain grid centric information, or contribution metadata).
+ */
+export interface WidgetSettings {
+    /**
+     * size of the widget (in case of configuration, this maps to the size sub section in the general section of the configuration panel)
+     */
+    size: WidgetSize;
+    /**
+     * name of the widget (in case of configuration, this maps to the name sub section in the general section of the configuration panel)
+     */
+    name: string;
+    /**
+     * settings of the widget
+     */
+    customSettings: CustomSettings;
+    /**
+     * Lightbox options
+     */
+    lightboxOptions?: LightboxOptions;
+}
+
+/**
+ * Used to differentiate between widget status helpers
+ */
+export enum WidgetStatusType {
+    /**
+     * The widget loaded successfully
+     */
+    Success = 0,
+    /**
+     * The widget failed to load
+     */
+    Failure = 1,
+    /**
+     * The widget needs to be configured
+     */
+    Unconfigured = 2
+}
+
+/**
+ * The object encapsulating the result for an IWidget/IConfigurableWidget method call. This object is created using the WidgetStatusHelper library.
+ */
+export interface WidgetStatus {
+    /**
+     * the rendered state of the widget serialized to a string.
+     */
+    state?: string;
+    /**
+     * Used to determine which widget status helper was called
+     */
+    statusType?: WidgetStatusType;
+}
+
+/**
+ * All widgets implement this interface
+ */
+export interface IWidget {
+    /** widgets use the settings provided along with the any cached data they may have to paint an interactive state. No network calls should be made by the widget.
+     *  @param {WidgetSettings} settings of the widget as available when the widget render is called by the host.
+     *  @returns object wrapped in a promise that encapsulates the success of this operation.
+     *          when this calls are completed and the experience is done loading.
+     */
+    preload: (widgetSettings: WidgetSettings) => Promise<WidgetStatus>;
+    /**
+     *  Widgets use the settings provided as well as server side calls to complete their rendering experience.
+     *  In the future, widgets are expected to provide a loading experience while the calls are being waited to be completed.
+     *  Until then, the widget host will provide the loading experience
+     *  @param {WidgetSettings} settings of the widget as available when the widget render is called by the host.
+     *  @returns object wrapped in a promise that encapsulates the success of this operation.
+     *          when this calls are completed and the experience is done loading.
+     */
+    load: (widgetSettings: WidgetSettings) => Promise<WidgetStatus>;
+    /**
+     * Widgets manage any operations that are not necessary for initial load but are required for the full widget experience.
+     */
+    onDashboardLoaded?: () => void;
+    /**
+     * The framework calls this method to determine if the widget should be disabled for users with stakeholder license
+     * @param {WidgetSettings} settings of the widget as available when the widget render is called by the host.
+     * @returns A boolean wrapped in a promise that determines if the widget should be disabled for users with stakeholder license
+     */
+    disableWidgetForStakeholders?: (widgetSettings: WidgetSettings) => Promise<boolean>;
+    /**
+     *  Run widget in lightboxed mode
+     *  @param {WidgetSettings} settings of the widget as available when the widget render is called by the host.
+     *  @param {LightboxSize} size of the lightbox
+     *  @returns object wrapped in a promise that encapsulates the success of this operation.
+     *          when this calls are completed and the experience is done loading.
+     */
+    lightbox?: (widgetSettings: WidgetSettings, lightboxSize: Size) => Promise<WidgetStatus>;
+    /**
+     *  Listen to message from host
+     * @param {string} type of event
+     * @param {eventArgs} arguments associated with the event.
+     */
+    listen?: <T>(event: string, eventArgs: EventArgs<T>) => void;
+}
+
+/**
+ * Configurable widgets implement this interface
+ */
+export interface IConfigurableWidget extends IWidget {
+    /**
+     *  When the configuration view is changed, the widget is expected to update its view.
+     *  @param {WidgetSettings} the latest widget settings as available from the configuration view for the widget.
+     *  @returns object wrapped in a promise that encapsulates the success of this operation.
+     */
+    reload: (newWidgetSettings: WidgetSettings) => Promise<WidgetStatus>;
+}
+
+/**
+ * Widget authors implement this interface for their configuration.
+ */
+export interface IWidgetConfiguration {
+    /**
+     *  Called by the host to setup the widget configuration, which uses the settings shared with the widget to complete its rendering experience.
+     *  @param {WidgetSettings} settings of the widget as shared with the configuration.
+     *  @param {IWidgetConfigurationContext} widgetConfigurationContext provided by the host of the widget configuration to allow for communication.
+     *  @returns object wrapped in a promise that encapsulates the success of this operation.
+     *           If load fails, returns error message via WidgetStatusHelper.Failure(errorMessage).
+     */
+    load: (widgetSettings: WidgetSettings, widgetConfigurationContext: IWidgetConfigurationContext) => Promise<WidgetStatus>;
+    /**
+     * Called by the host when the user clicks on the Save button.
+     * Widget author is expected to run validations if needed.
+     * If ready to save, then use WidgetHelpers.WidgetConfigurationSave.Valid() to return the serialized custom settings of the widget from the configuraton.
+     * If custom settings are not valid and so not ready to save, then  use WidgetHelpers.WidgetConfigurationSave.Invalid() to notify the host to stop save.
+     * @returns object of type SaveStatus wrapped in a promise.
+     */
+    onSave: () => Promise<SaveStatus>;
+    /**
+     * (Optional) Called by the host when the configuration is ready to be saved (when the user clicks the save button on the configuration panel)
+     */
+    onSaveComplete?: () => void;
+    /**
+     *  Listen to message from host
+     * @param {string} type of event
+     * @param {eventArgs} arguments associated with the event.
+     */
+    listen?: <T>(event: string, eventArgs: EventArgs<T>) => void;
+}
+
+/**
+ * The result of a notification being made by a widget configuration.
+ */
+export interface NotifyResult {
+    /**
+     * Gets a response from the subscriber of the notification, if they provide one as part of the schema for the event.
+     * @returns A promise with the data representing the return payload serialized as a string.
+     */
+    getResponse(): Promise<string>;
+}
+
+/**
+ * Arguments associated with an event being passed by a widget or configurations.
+ */
+export interface EventArgs<T> {
+    /**
+     * Data relevant to the event.
+     */
+    data: T;
+}
+
+/**
+ * Interface for the object passed to the widget configuration to communicate with its host.
+ */
+export interface IWidgetConfigurationContext {
+    /**
+     * The widget configuration calls this method when it wants to notify any of the WidgetEvents to the host
+     * @param {string} type of event
+     * @param {eventArgs} arguments associated with the event which comes from the widget configuration.
+     * @returns a promise with the result of the notification. If arguments are malformed, the promise will be rejected. If multiple notifications are made for the same event
+     * only the promise for the latest notification is resolved and the rest are treated as stale. The subscriber of the notification can send back information in a serialized form.
+     */
+    notify: <T>(event: string, eventArgs: EventArgs<T>) => Promise<NotifyResult>;
+}
+
+/**
+ * Interface for the object passed to the host when user clicks on the Save button in the configuration pane
+ */
+export interface SaveStatus {
+    /**
+     * The custom settings to save
+     */
+    customSettings?: CustomSettings;
+    /**
+     * Indicates validity of the customSettings. If false, then user will be shown a generic error message and settings will not be saved.
+     */
+    isValid: boolean;
+}
+
+/**
+ * Size of lightbox to draw widget in
+ */
+export interface Size {
+    /**
+     * width in pixels
+     */
+    width: number;
+    /**
+     * height in pixels
+     */
+    height: number;
+}

--- a/src/Dashboard/WidgetHelpers.ts
+++ b/src/Dashboard/WidgetHelpers.ts
@@ -1,0 +1,145 @@
+/**
+ * From /Tfs/WebPlatform/Client/TFS/Dashboards/WidgetHelpers.ts
+ */
+
+import { CustomSettings, SaveStatus, WidgetStatus, WidgetStatusType } from "./WidgetContracts";
+
+export class WidgetStatusHelper {
+    /**
+     * method to encapsulate a successful result for a widget loading operation (load, reload, openLightbox etc)
+     * @param state any state information to be passed to the initiator of the loading call. 
+     * @param title title for the lightbox of a widget when available. 
+     * @returns promise encapsulating the status of the widget loading operations. 
+     */
+    public static Success(state?: string): Promise<WidgetStatus> {
+        return Promise.resolve(<WidgetStatus>{
+            state: state,
+            statusType: WidgetStatusType.Success
+        });
+    }
+
+    /**
+     * method to encapsulate a failed result for a widget loading operation (load, reload, openLightbox etc)
+     * @param message message to display as part within the widget error experience. 
+     * @param isUserVisible indicates whether the message should be displayed to the user or a generic error message displayed. Defaults to true.
+     * @param isRichText indicates whether the message is an html that can be rendered as a rich experience. Defaults to false. Only trusted extensions are 
+     * allowed to set this to true. For any 3rd party widgets passing this value as true, it will be ignored. 
+     * @returns promise encapsulating the status of the widget loading operations. 
+     */
+    public static Failure(message: string, isUserVisible: boolean = true, isRichText: boolean = false): Promise<WidgetStatus> {
+        return Promise.reject({
+            message: message,
+            isRichText: isRichText,
+            isUserVisible: isUserVisible
+        });
+    }
+
+    /**
+     * method to encapsulate a result for a widget loading operation that results in the widget being in an unconfigured state. 
+     * @returns promise encapsulating the status of the widget loading operations. 
+     */
+    public static Unconfigured(): Promise<WidgetStatus> {
+        return Promise.resolve(<WidgetStatus>{
+            statusType: WidgetStatusType.Unconfigured
+        });
+    }
+}
+
+export class WidgetConfigurationSave {
+    /**
+     * method to encapsulate a valid state that is returned by the widget configuration
+     * @param customSettings settings from the widget configuration to be returned as part of this state. 
+     * @returns promise encapsulating the state being returned.
+     */
+    public static Valid(customSettings: CustomSettings): Promise<SaveStatus> {
+        return Promise.resolve({
+            customSettings: customSettings,
+            isValid: true
+        });
+    }
+
+    /**
+     * method to encapsulate an invalid state that is returned by the widget configuration
+     * @returns promise encapsulating the state being returned.
+     */
+    public static Invalid(): Promise<SaveStatus> {
+        return Promise.reject({
+            isValid: false
+        });
+    }
+}
+
+export class WidgetSizeConverter {
+    /**
+    * Cell width of the grid that is used to draw the widgets, this includes the border around the widget (i.e. this is the size of the div, border included)
+    */
+    private static CellWidth: number = 160;
+
+    /**
+    * Cell height of the grid that is used to draw the widgets, this includes the border around the widget (i.e. this is the size of the div, border included)
+    */
+    private static CellHeight: number = 160;
+
+    /**
+    * Cell gutter width between the cells that is used to draw the widget, this excludes the border around the widget (i.e. this is distance between widgets)
+    */
+    private static CellMarginWidth: number = 10;
+
+    /**
+    * Cell gutter height between the cells that is used to draw the widget, this excludes the border around the widget  (i.e. this is distance between widgets)
+    */
+    private static CellMarginHeight: number = 10;
+
+    /**
+    * Calculates a dimension in pixels, given widget cell size and grid dimensions
+    * @returns size in pixels
+    */
+    private static CalculatePixelSize(cellCount: number, gridCellSize: number, gridMarginSize: number): number {
+        //the dimensions of a multi-celled widget are a combination of space of the occupied cells AND the margins between those cells
+        var marginCount = cellCount - 1;
+        return gridCellSize * cellCount + gridMarginSize * marginCount;
+    }
+
+    /**
+    * @returns width in pixels for 1x1 widget
+    */
+    public static GetWidgetWidth(): number {
+        return WidgetSizeConverter.CellWidth;
+    }
+
+    /**
+    * @returns height in pixels for 1x1 widget
+    */
+    public static GetWidgetHeight(): number {
+        return WidgetSizeConverter.CellHeight;
+    }
+
+    /**
+    * @returns width in pixels for widget gutter
+    */
+    public static GetWidgetMarginWidth(): number {
+        return WidgetSizeConverter.CellMarginWidth;
+    }
+
+    /**
+    *  @returns height in pixels for widget gutter
+    */
+    public static GetWidgetMarginHeight(): number {
+        return WidgetSizeConverter.CellMarginHeight;
+    }
+    /**
+    * Converts widget column span into pixels
+    * @returns width in pixels
+    */
+    public static ColumnsToPixelWidth(columnSpan: number): number {
+        return this.CalculatePixelSize(columnSpan, WidgetSizeConverter.GetWidgetWidth(), WidgetSizeConverter.GetWidgetMarginWidth());
+    }
+
+    /**
+    * Converts widget row span into pixels
+    * @returns height in pixels
+    */
+    public static RowsToPixelHeight(rowSpan: number): number {
+        return this.CalculatePixelSize(rowSpan, WidgetSizeConverter.GetWidgetHeight(), WidgetSizeConverter.GetWidgetMarginHeight());
+    }
+}

--- a/src/Dashboard/index.ts
+++ b/src/Dashboard/index.ts
@@ -1,2 +1,5 @@
 export * from "./Dashboard";
 export * from "./DashboardClient";
+export * from "./WidgetConfigHelpers";
+export * from "./WidgetContracts";
+export * from "./WidgetHelpers";


### PR DESCRIPTION
These additions are required to support Widget extension contributions in conjunction with [azure-devops-extension-sdk](https://github.com/microsoft/azure-devops-extension-sdk).

Most of the content is types: enums, interfaces, etc.  Everything added comes from the ADO repo with paths as noted at the top of each file.  All code was also originally available via the [vss-web-extension-sdk](https://github.com/microsoft/vss-web-extension-sdk) repo.

Addresses issues [17](https://github.com/microsoft/azure-devops-extension-sdk/issues/17) & [22](https://github.com/microsoft/azure-devops-extension-sdk/issues/22) in the [azure-devops-extension-sdk](https://github.com/microsoft/azure-devops-extension-sdk) repo.